### PR TITLE
ci: add GitHub Action workflow 'Test'

### DIFF
--- a/.github/test.tcl
+++ b/.github/test.tcl
@@ -1,0 +1,2 @@
+source ./OsvvmLibraries/Scripts/StartUp.tcl
+build ./OsvvmLibraries/OsvvmLibraries.pro

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,85 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 15 * * *'
+
+jobs:
+
+
+  lin:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        backend:
+          - mcode
+          - llvm
+          - gcc
+    name: '🐧 Ubuntu · ${{ matrix.backend }}'
+    steps:
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+      with:
+        path: OsvvmLibraries
+        submodules: recursive
+
+    - name: '⚙️ Setup GHDL'
+      uses: ghdl/setup-ghdl-ci@master
+      with:
+        backend: ${{ matrix.backend }}
+
+    - name: '🛠️ Install tcl'
+      run: |
+        sudo apt update -qq
+        sudo apt install -y tcl
+
+    - name: '🚧 Run tests'
+      run: tclsh ./OsvvmLibraries/.github/test.tcl
+
+
+  win:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include: [
+          #{icon: '🟪', bits: "32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
+          {icon: '🟦', bits: '64', arch: x86_64, pkg: 'llvm'  },
+          {icon: '🟪', bits: '32', arch: i686,   pkg: 'mcode' },
+          #{icon: '🟦', bits: "64", arch: x86_64, pkg: "mcode" }, ! simulation with mcode is not yet supported on win64
+        ]
+    name: '${{ matrix.icon }} MSYS2 · ${{ matrix.pkg }}${{ matrix.bits }} '
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - name: '${{ matrix.icon }} Setup MSYS2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW${{ matrix.bits }}
+        update: true
+        install: >
+          git
+          mingw-w64-${{ matrix.arch }}-tcl
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+      with:
+        path: OsvvmLibraries
+        submodules: recursive
+
+    - name: '⚙️ Setup GHDL'
+      uses: ghdl/setup-ghdl-ci@master
+      with:
+        backend: ${{ matrix.pkg }}
+
+    - name: '🚧 Run tests'
+      run: tclsh ./OsvvmLibraries/.github/test.tcl


### PR DESCRIPTION
As discussed in gitter and in a meeting, this PR adds a CI workflow for testing OSVVM with latest GHDL.

- On Linux, the three backends are tested. On Windows/MSYS2, mcode32 and llvm64 are tested.
  - The installation of the dependencies is slightly different, but it's equivalent.
- In CI, this repository is cloned recursively into `./OsvvmLibraries` using actions/checkout.
- An entrypoint TCL script is added in this PR (`.github/test.tcl`). 
- Therefore, the test command in CI is `tclsh ./OsvvmLibraries/.github/test.tcl` (both on Linux and on Windows/MSYS2).

Currently, 4/5 jobs are successful: https://github.com/umarcor/OsvvmLibraries/actions/runs/1043073946. GCC backend on Ubuntu fails:

```
analyze ./src/StreamTransactionPkg.vhd
/home/runner/work/OsvvmLibraries/OsvvmLibraries/VHDL_LIBS/GHDL-2.0.0-dev/osvvm_common/v08/StreamTransactionPkg.s: Assembler messages:
/home/runner/work/OsvvmLibraries/OsvvmLibraries/VHDL_LIBS/GHDL-2.0.0-dev/osvvm_common/v08/StreamTransactionPkg.s:1702: Error: symbol `osvvm_common__streamtransactionpkg__streamrectype__burstfifo__RTISTR' is already defined
ghdl: compilation error
```

@JimLewis, how do you want to proceed? Shall we comment out line 21 of the workflow (that will disable it temporarily)?