### PR TITLE
ci: install tcllib

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: '🛠️ Install tcl'
       run: |
         sudo apt update -qq
-        sudo apt install -y tcl
+        sudo apt install -y tcl tcllib
 
     - name: '🚧 Run tests'
       run: tclsh ./OsvvmLibraries/.github/test.tcl


### PR DESCRIPTION
This PR add `tcllib` to Ubuntu and MSYS2 jobs, so that YAML parsing features are available in TCL.