### PR TITLE
ci: add UCRT64 job to MSYS2 matrix

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         backend:
           - mcode
@@ -59,7 +58,6 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         include:
           #- {icon: '🟪', msys: 'MINGW32', arch: i686,        pkg: "llvm" } ! Not yet functional


### PR DESCRIPTION
There is a new experimental environment provided by MSYS2 named UCRT64. A few days ago, support for Ada was added, which allowed to build GHDL on that environment. Since a few hours ago, Action setup-ghdl-ci allows using that environment.

This PR adds a job to the Windows matrix for testing UCRT64, along with the existing MINGW32 and MINGW64.

/cc @Paebbels