### PR TITLE
ci: simplify MSYS2 matrix using 'pacboy'

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -69,12 +69,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          #- {icon: '🟪', msys: 'MINGW32', arch: i686,        pkg: "llvm" } ! Not yet functional
-          - {icon: '🟦', msys: 'MINGW64', arch: x86_64,      pkg: 'llvm' }
-          - {icon: '🟨', msys: 'UCRT64',  arch: ucrt-x86_64, pkg: 'llvm' } #! Experimental
-          - {icon: '🟪', msys: 'MINGW32', arch: i686,        pkg: 'mcode' }
-          #- {icon: '🟦', msys: 'MINGW64', arch: x86_64,      pkg: "mcode" } ! Simulation with mcode is not yet supported on win64
-          #- {icon: '🟨', msys: 'UCRT64',  arch: x86_64,      pkg: "mcode" } ! Experimental; Simulation with mcode is not yet supported on win64
+          #- {icon: '🟪', msys: 'MINGW32', pkg: "llvm"  } ! Not yet functional
+          - {icon: '🟦', msys: 'MINGW64', pkg: 'llvm'  }
+          - {icon: '🟨', msys: 'UCRT64',  pkg: 'llvm'  } #! Experimental
+          - {icon: '🟪', msys: 'MINGW32', pkg: 'mcode' }
+          #- {icon: '🟦', msys: 'MINGW64', pkg: "mcode" } ! Simulation with mcode is not yet supported on win64
+          #- {icon: '🟨', msys: 'UCRT64',  pkg: "mcode" } ! Experimental; Simulation with mcode is not yet supported on win64
     name: '${{ matrix.icon }} ${{ matrix.msys }} · ${{ matrix.pkg }}'
     defaults:
       run:
@@ -86,10 +86,8 @@ jobs:
       with:
         msystem: ${{ matrix.msys }}
         update: true
-        install: >
-          git
-          mingw-w64-${{ matrix.arch }}-tcl
-          mingw-w64-${{ matrix.arch }}-tcllib
+        install: git
+        pacboy: tcl:p tcllib:p
 
     - name: '🧰 Checkout'
       uses: actions/checkout@v2


### PR DESCRIPTION
Option `pacboy` was added to the GitHub Action we use for setting up MSYS2. That option allows simplifying the workflow matrix, since we don't need to handle field `arch` explicitly.

This PR is functionally equivalent, just a cleanup.